### PR TITLE
fix: assign port for codex

### DIFF
--- a/src/GreenhouseMonitor/Enarx.toml
+++ b/src/GreenhouseMonitor/Enarx.toml
@@ -10,7 +10,7 @@ kind = "stderr"
 [[files]]
 kind = "listen"
 prot = "tcp"
-port = 5000
+port = 11000
 name = "SERVER"
 addr = "0.0.0.0"
 


### PR DESCRIPTION
Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
